### PR TITLE
fix: 修复死链

### DIFF
--- a/source/_posts/develop/api/apilist.md
+++ b/source/_posts/develop/api/apilist.md
@@ -56,7 +56,7 @@ sidebar: apilist
 
 |API 名称|解释|
 |--|--|
-|<a href="http://localhost:4000/docs/develop/api/media_image/#swan-chooseImage/">swan.chooseImage</a>|从本地相册选择图片或使用相机拍照。|
+|<a href="/develop/api/media_image/#swan-chooseImage/">swan.chooseImage</a>|从本地相册选择图片或使用相机拍照。|
 |<a href="https://smartprogram.baidu.com/docs/develop/api/media_image/#swan-previewImage/">swan.previewImage</a>|预览图片|
 |<a href="https://smartprogram.baidu.com/docs/develop/api/media_image/#swan-getImageInfo/">swan.getImageInfo</a>|获取图片信息|
 |<a href="https://smartprogram.baidu.com/docs/develop/api/media_image/#swan-saveImageToPhotosAlbum/">swan.saveImageToPhotosAlbum</a>|保存图片到系统相册，需要用户授权。|

--- a/source/_posts/introduction/authenticity.md
+++ b/source/_posts/introduction/authenticity.md
@@ -4,7 +4,7 @@ header: introduction
 nav: book
 sidebar: authenticity
 ---
-特别说明：该环节主要用于验证主体真实性，为不影响到开发进展，可暂时跳过此步骤直接<a href="http://http://smartprogram.baidu.com/docs/introduction/register_consummate/#%E5%AE%8C%E5%96%84%E5%9F%BA%E6%9C%AC%E4%BF%A1%E6%81%AF/">创建</a>小程序，并在小程序的开发过程中任意时间完成真实性认证即可，真实性认证状态将影响提交代码包及发布上线。
+特别说明：该环节主要用于验证主体真实性，为不影响到开发进展，可暂时跳过此步骤直接<a href="/introduction/register_consummate/#%E5%AE%8C%E5%96%84%E5%9F%BA%E6%9C%AC%E4%BF%A1%E6%81%AF/">创建</a>小程序，并在小程序的开发过程中任意时间完成真实性认证即可，真实性认证状态将影响提交代码包及发布上线。
 
 ![图片](../../img/introduction/register/1.7.png)
 

--- a/source/_posts/introduction/publish.md
+++ b/source/_posts/introduction/publish.md
@@ -8,7 +8,7 @@ sidebar: publish
 
 ### 上线前准备
 提交审核前需确保完成以下2个步骤，否则小程序将无法提交代码包及发布上线。
-1.	<a href="http://localhost:4000/docs/introduction/authenticity/#%E5%AF%B9%E5%85%AC%E9%AA%8C%E8%AF%81/">真实性认证</a>审核通过 
+1.	<a href="/introduction/authenticity/">真实性认证</a>审核通过 
 2.	服务类目审核通过 
 
 #### 在开发者后台可点击“发布”按钮完成小程序上线发布操作。


### PR DESCRIPTION
感觉原始文档中不应该写绝对链接 <https://smartprogram.baidu.com/docs> 吧，因为 Hexo 配置了 `url` 、`root` ，直接使用 `/introduction/register_consummate/` 可以让链接适配的更好。 🥂 